### PR TITLE
SPL add crypto functions

### DIFF
--- a/include/sys/crypto/api.h
+++ b/include/sys/crypto/api.h
@@ -1,0 +1,423 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2003, 2010, Oracle and/or its affiliates. All rights reserved.
+ */
+
+#ifndef	_SYS_CRYPTO_API_H
+#define	_SYS_CRYPTO_API_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <sys/crypto/common.h>
+
+typedef long crypto_req_id_t;
+typedef void *crypto_bc_t;
+typedef void *crypto_context_t;
+typedef void *crypto_ctx_template_t;
+
+typedef uint32_t crypto_call_flag_t;
+
+/* crypto_call_flag's values */
+#define	CRYPTO_ALWAYS_QUEUE	0x00000001	/* ALWAYS queue the req. */
+#define	CRYPTO_NOTIFY_OPDONE	0x00000002	/* Notify intermediate steps */
+#define	CRYPTO_SKIP_REQID	0x00000004	/* Skip request ID generation */
+
+typedef struct {
+	crypto_call_flag_t	cr_flag;
+	void			(*cr_callback_func)(void *, int);
+	void			*cr_callback_arg;
+	crypto_req_id_t		cr_reqid;
+} crypto_call_req_t;
+
+/*
+ * Returns the mechanism type corresponding to a mechanism name.
+ */
+
+#define	CRYPTO_MECH_INVALID	((uint64_t)-1)
+extern crypto_mech_type_t crypto_mech2id(crypto_mech_name_t name);
+
+/*
+ * Create and destroy context templates.
+ */
+extern int crypto_create_ctx_template(crypto_mechanism_t *mech,
+    crypto_key_t *key, crypto_ctx_template_t *tmpl, int kmflag);
+extern void crypto_destroy_ctx_template(crypto_ctx_template_t tmpl);
+
+/*
+ * Single and multi-part digest operations.
+ */
+extern int crypto_digest(crypto_mechanism_t *mech, crypto_data_t *data,
+    crypto_data_t *digest, crypto_call_req_t *cr);
+extern int crypto_digest_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_data_t *, crypto_data_t *,
+    crypto_call_req_t *);
+extern int crypto_digest_init(crypto_mechanism_t *mech, crypto_context_t *ctxp,
+    crypto_call_req_t *cr);
+extern int crypto_digest_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_context_t *, crypto_call_req_t *);
+extern int crypto_digest_update(crypto_context_t ctx, crypto_data_t *data,
+    crypto_call_req_t *cr);
+extern int crypto_digest_final(crypto_context_t ctx, crypto_data_t *digest,
+    crypto_call_req_t *cr);
+
+/*
+ * Single and multi-part MAC operations.
+ */
+extern int crypto_mac(crypto_mechanism_t *mech, crypto_data_t *data,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *mac,
+    crypto_call_req_t *cr);
+extern int crypto_mac_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_data_t *, crypto_key_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_mac_verify(crypto_mechanism_t *mech, crypto_data_t *data,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *mac,
+    crypto_call_req_t *cr);
+extern int crypto_mac_verify_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_data_t *, crypto_key_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_mac_init(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_ctx_template_t tmpl, crypto_context_t *ctxp, crypto_call_req_t *cr);
+extern int crypto_mac_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_context_t *, crypto_call_req_t *);
+extern int crypto_mac_update(crypto_context_t ctx, crypto_data_t *data,
+    crypto_call_req_t *cr);
+extern int crypto_mac_final(crypto_context_t ctx, crypto_data_t *data,
+    crypto_call_req_t *cr);
+
+/*
+ * Single and multi-part sign with private key operations.
+ */
+extern int crypto_sign(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_data_t *data, crypto_ctx_template_t tmpl,
+    crypto_data_t *signature, crypto_call_req_t *cr);
+extern int crypto_sign_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_data_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_sign_init(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_ctx_template_t tmpl, crypto_context_t *ctxp, crypto_call_req_t *cr);
+extern int crypto_sign_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_context_t *, crypto_call_req_t *);
+extern int crypto_sign_update(crypto_context_t ctx, crypto_data_t *data,
+    crypto_call_req_t *cr);
+extern int crypto_sign_final(crypto_context_t ctx, crypto_data_t *signature,
+    crypto_call_req_t *cr);
+extern int crypto_sign_recover_init_prov(crypto_provider_t,
+    crypto_session_id_t, crypto_mechanism_t *, crypto_key_t *,
+    crypto_ctx_template_t tmpl, crypto_context_t *, crypto_call_req_t *);
+extern int crypto_sign_recover(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_data_t *data, crypto_ctx_template_t tmpl, crypto_data_t *signature,
+    crypto_call_req_t *cr);
+extern int crypto_sign_recover_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_data_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+
+/*
+ * Single and multi-part verify with public key operations.
+ */
+extern int crypto_verify(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_data_t *data, crypto_ctx_template_t tmpl, crypto_data_t *signature,
+    crypto_call_req_t *cr);
+extern int crypto_verify_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_data_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_verify_init(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_ctx_template_t tmpl, crypto_context_t *ctxp, crypto_call_req_t *cr);
+extern int crypto_verify_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_context_t *, crypto_call_req_t *);
+extern int crypto_verify_update(crypto_context_t ctx, crypto_data_t *data,
+    crypto_call_req_t *cr);
+extern int crypto_verify_final(crypto_context_t ctx, crypto_data_t *signature,
+    crypto_call_req_t *cr);
+extern int crypto_verify_recover_init_prov(crypto_provider_t,
+    crypto_session_id_t, crypto_mechanism_t *, crypto_key_t *,
+    crypto_ctx_template_t tmpl, crypto_context_t *, crypto_call_req_t *);
+extern int crypto_verify_recover(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_data_t *signature, crypto_ctx_template_t tmpl, crypto_data_t *data,
+    crypto_call_req_t *cr);
+extern int crypto_verify_recover_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_data_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+
+/*
+ * Single and multi-part encryption operations.
+ */
+extern int crypto_encrypt(crypto_mechanism_t *mech, crypto_data_t *plaintext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *ciphertext,
+    crypto_call_req_t *cr);
+extern int crypto_encrypt_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_data_t *, crypto_key_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_encrypt_init(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_ctx_template_t tmpl, crypto_context_t *ctxp, crypto_call_req_t *cr);
+extern int crypto_encrypt_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_context_t *, crypto_call_req_t *);
+extern int crypto_encrypt_update(crypto_context_t ctx,
+    crypto_data_t *plaintext, crypto_data_t *ciphertext,
+    crypto_call_req_t *cr);
+extern int crypto_encrypt_final(crypto_context_t ctx,
+    crypto_data_t *ciphertext, crypto_call_req_t *cr);
+
+/*
+ * Single and multi-part decryption operations.
+ */
+extern int crypto_decrypt(crypto_mechanism_t *mech, crypto_data_t *ciphertext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *plaintext,
+    crypto_call_req_t *cr);
+extern int crypto_decrypt_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_data_t *, crypto_key_t *,
+    crypto_ctx_template_t, crypto_data_t *, crypto_call_req_t *);
+extern int crypto_decrypt_init(crypto_mechanism_t *mech, crypto_key_t *key,
+    crypto_ctx_template_t tmpl, crypto_context_t *ctxp,
+    crypto_call_req_t *cr);
+extern int crypto_decrypt_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_context_t *, crypto_call_req_t *);
+extern int crypto_decrypt_update(crypto_context_t ctx,
+    crypto_data_t *ciphertext, crypto_data_t *plaintext,
+    crypto_call_req_t *cr);
+extern int crypto_decrypt_final(crypto_context_t ctx, crypto_data_t *plaintext,
+    crypto_call_req_t *cr);
+
+/*
+ * Single and multi-part encrypt/MAC dual operations.
+ */
+extern int crypto_encrypt_mac(crypto_mechanism_t *encr_mech,
+    crypto_mechanism_t *mac_mech, crypto_data_t *pt,
+    crypto_key_t *encr_key, crypto_key_t *mac_key,
+    crypto_ctx_template_t encr_tmpl, crypto_ctx_template_t mac_tmpl,
+    crypto_dual_data_t *ct, crypto_data_t *mac, crypto_call_req_t *cr);
+extern int crypto_encrypt_mac_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_mechanism_t *, crypto_data_t *,
+    crypto_key_t *, crypto_key_t *, crypto_ctx_template_t,
+    crypto_ctx_template_t, crypto_dual_data_t *, crypto_data_t *,
+    crypto_call_req_t *);
+extern int crypto_encrypt_mac_init(crypto_mechanism_t *encr_mech,
+    crypto_mechanism_t *mac_mech, crypto_key_t *encr_key,
+    crypto_key_t *mac_key, crypto_ctx_template_t encr_tmpl,
+    crypto_ctx_template_t mac_tmpl, crypto_context_t *ctxp,
+    crypto_call_req_t *cr);
+extern int crypto_encrypt_mac_init_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_mechanism_t *, crypto_key_t *, crypto_key_t *,
+    crypto_ctx_template_t, crypto_ctx_template_t, crypto_context_t *,
+    crypto_call_req_t *);
+extern int crypto_encrypt_mac_update(crypto_context_t ctx,
+    crypto_data_t *pt, crypto_dual_data_t *ct, crypto_call_req_t *cr);
+extern int crypto_encrypt_mac_final(crypto_context_t ctx,
+    crypto_dual_data_t *ct, crypto_data_t *mac, crypto_call_req_t *cr);
+
+/*
+ * Single and multi-part MAC/decrypt dual operations.
+ */
+extern int crypto_mac_decrypt(crypto_mechanism_t *mac_mech,
+    crypto_mechanism_t *decr_mech, crypto_dual_data_t *ct,
+    crypto_key_t *mac_key, crypto_key_t *decr_key,
+    crypto_ctx_template_t mac_tmpl, crypto_ctx_template_t decr_tmpl,
+    crypto_data_t *mac, crypto_data_t *pt, crypto_call_req_t *cr);
+extern int crypto_mac_decrypt_prov(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *mac_mech, crypto_mechanism_t *decr_mech,
+    crypto_dual_data_t *ct, crypto_key_t *mac_key, crypto_key_t *decr_key,
+    crypto_ctx_template_t mac_tmpl, crypto_ctx_template_t decr_tmpl,
+    crypto_data_t *mac, crypto_data_t *pt, crypto_call_req_t *cr);
+extern int crypto_mac_verify_decrypt(crypto_mechanism_t *mac_mech,
+    crypto_mechanism_t *decr_mech, crypto_dual_data_t *ct,
+    crypto_key_t *mac_key, crypto_key_t *decr_key,
+    crypto_ctx_template_t mac_tmpl, crypto_ctx_template_t decr_tmpl,
+    crypto_data_t *mac, crypto_data_t *pt, crypto_call_req_t *cr);
+extern int crypto_mac_verify_decrypt_prov(crypto_provider_t,
+    crypto_session_id_t, crypto_mechanism_t *mac_mech,
+    crypto_mechanism_t *decr_mech, crypto_dual_data_t *ct,
+    crypto_key_t *mac_key, crypto_key_t *decr_key,
+    crypto_ctx_template_t mac_tmpl, crypto_ctx_template_t decr_tmpl,
+    crypto_data_t *mac, crypto_data_t *pt, crypto_call_req_t *cr);
+extern int crypto_mac_decrypt_init(crypto_mechanism_t *mac_mech,
+    crypto_mechanism_t *decr_mech, crypto_key_t *mac_key,
+    crypto_key_t *decr_key, crypto_ctx_template_t mac_tmpl,
+    crypto_ctx_template_t decr_tmpl, crypto_context_t *ctxp,
+    crypto_call_req_t *cr);
+extern int crypto_mac_decrypt_init_prov(crypto_provider_t,
+    crypto_session_id_t, crypto_mechanism_t *mac_mech,
+    crypto_mechanism_t *decr_mech, crypto_key_t *mac_key,
+    crypto_key_t *decr_key, crypto_ctx_template_t mac_tmpl,
+    crypto_ctx_template_t decr_tmpl, crypto_context_t *ctxp,
+    crypto_call_req_t *cr);
+extern int crypto_mac_decrypt_update(crypto_context_t ctx,
+    crypto_dual_data_t *ct, crypto_data_t *pt, crypto_call_req_t *cr);
+extern int crypto_mac_decrypt_final(crypto_context_t ctx, crypto_data_t *mac,
+    crypto_data_t *pt, crypto_call_req_t *cr);
+
+/* Session Management */
+extern int crypto_session_open(crypto_provider_t, crypto_session_id_t *,
+    crypto_call_req_t *);
+extern int crypto_session_close(crypto_provider_t, crypto_session_id_t,
+    crypto_call_req_t *);
+extern int crypto_session_login(crypto_provider_t, crypto_session_id_t,
+    crypto_user_type_t, char *, size_t, crypto_call_req_t *);
+extern int crypto_session_logout(crypto_provider_t, crypto_session_id_t,
+    crypto_call_req_t *);
+
+/* Object Management */
+extern int crypto_object_copy(crypto_provider_t, crypto_session_id_t,
+    crypto_object_id_t, crypto_object_attribute_t *, uint_t,
+    crypto_object_id_t *, crypto_call_req_t *);
+extern int crypto_object_create(crypto_provider_t, crypto_session_id_t,
+    crypto_object_attribute_t *, uint_t, crypto_object_id_t *,
+    crypto_call_req_t *);
+extern int crypto_object_destroy(crypto_provider_t, crypto_session_id_t,
+    crypto_object_id_t, crypto_call_req_t *);
+extern int crypto_object_get_attribute_value(crypto_provider_t,
+    crypto_session_id_t, crypto_object_id_t, crypto_object_attribute_t *,
+    uint_t, crypto_call_req_t *);
+extern int crypto_object_get_size(crypto_provider_t, crypto_session_id_t,
+    crypto_object_id_t, size_t *, crypto_call_req_t *);
+extern int crypto_object_find_final(crypto_provider_t, void *,
+    crypto_call_req_t *);
+extern int crypto_object_find_init(crypto_provider_t, crypto_session_id_t,
+    crypto_object_attribute_t *, uint_t, void **, crypto_call_req_t *);
+extern int crypto_object_find(crypto_provider_t, void *, crypto_object_id_t *,
+    uint_t *, uint_t, crypto_call_req_t *);
+extern int crypto_object_set_attribute_value(crypto_provider_t,
+    crypto_session_id_t, crypto_object_id_t, crypto_object_attribute_t *,
+    uint_t, crypto_call_req_t *);
+
+/* Key Management */
+extern int crypto_key_derive(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_object_attribute_t *,
+    uint_t, crypto_object_id_t *, crypto_call_req_t *);
+extern int crypto_key_generate(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_object_attribute_t *, uint_t,
+    crypto_object_id_t *, crypto_call_req_t *);
+extern int crypto_key_generate_pair(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_object_attribute_t *, uint_t,
+    crypto_object_attribute_t *, uint_t, crypto_object_id_t *,
+    crypto_object_id_t *, crypto_call_req_t *);
+extern int crypto_key_unwrap(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, uchar_t *, size_t *,
+    crypto_object_attribute_t *, uint_t, crypto_object_id_t *,
+    crypto_call_req_t *);
+extern int crypto_key_wrap(crypto_provider_t, crypto_session_id_t,
+    crypto_mechanism_t *, crypto_key_t *, crypto_object_id_t *, uchar_t *,
+    size_t *, crypto_call_req_t *);
+extern int crypto_key_check_prov(crypto_provider_t, crypto_mechanism_t *mech,
+    crypto_key_t *key);
+extern int crypto_key_check(crypto_mechanism_t *mech, crypto_key_t *key);
+
+
+/*
+ * Routines to cancel a single asynchronous request or all asynchronous
+ * requests associated with a particular context.
+ */
+extern void crypto_cancel_req(crypto_req_id_t req);
+extern void crypto_cancel_ctx(crypto_context_t ctx);
+
+/*
+ * crypto_get_mech_list(9F) allocates and returns the list of currently
+ * supported cryptographic mechanisms.
+ */
+extern crypto_mech_name_t *crypto_get_mech_list(uint_t *count, int kmflag);
+extern void crypto_free_mech_list(crypto_mech_name_t *mech_names,
+    uint_t count);
+
+extern crypto_provider_t crypto_get_provider(char *, char *, char *);
+extern int crypto_get_provinfo(crypto_provider_t, crypto_provider_ext_info_t *);
+extern void crypto_release_provider(crypto_provider_t);
+
+/*
+ * A kernel consumer can request to be notified when some particular event
+ * occurs. The valid events, callback function type, and functions to
+ * be called to register or unregister for notification are defined below.
+ */
+
+#define	CRYPTO_EVENT_MECHS_CHANGED		0x00000001
+#define	CRYPTO_EVENT_PROVIDER_REGISTERED	0x00000002
+#define	CRYPTO_EVENT_PROVIDER_UNREGISTERED	0x00000004
+
+typedef enum {
+	CRYPTO_MECH_ADDED = 1,
+	CRYPTO_MECH_REMOVED
+} crypto_event_change_t;
+
+/* The event_arg argument structure for CRYPTO_EVENT_PROVIDERS_CHANGE event */
+typedef struct crypto_notify_event_change {
+	crypto_mech_name_t ec_mech_name;
+	crypto_provider_type_t ec_provider_type;
+	crypto_event_change_t ec_change;
+} crypto_notify_event_change_t;
+
+typedef void *crypto_notify_handle_t;
+typedef void (*crypto_notify_callback_t)(uint32_t event_mask, void *event_arg);
+
+extern crypto_notify_handle_t crypto_notify_events(
+    crypto_notify_callback_t nf, uint32_t event_mask);
+extern void crypto_unnotify_events(crypto_notify_handle_t);
+
+/*
+ * crypto_bufcall(9F) group of routines.
+ */
+extern crypto_bc_t crypto_bufcall_alloc(void);
+extern int crypto_bufcall_free(crypto_bc_t bc);
+extern int crypto_bufcall(crypto_bc_t bc, void (*func)(void *arg), void *arg);
+extern int crypto_unbufcall(crypto_bc_t bc);
+
+/*
+ * To obtain the list of key size ranges supported by a mechanism.
+ */
+
+#define	CRYPTO_MECH_USAGE_ENCRYPT	0x00000001
+#define	CRYPTO_MECH_USAGE_DECRYPT	0x00000002
+#define	CRYPTO_MECH_USAGE_MAC		0x00000004
+
+typedef	uint32_t crypto_mech_usage_t;
+
+typedef struct crypto_mechanism_info {
+	size_t mi_min_key_size;
+	size_t mi_max_key_size;
+	crypto_keysize_unit_t mi_keysize_unit; /* for mi_xxx_key_size */
+	crypto_mech_usage_t mi_usage;
+} crypto_mechanism_info_t;
+
+#ifdef	_SYSCALL32
+
+typedef struct crypto_mechanism_info32 {
+	size32_t mi_min_key_size;
+	size32_t mi_max_key_size;
+	crypto_keysize_unit_t mi_keysize_unit; /* for mi_xxx_key_size */
+	crypto_mech_usage_t mi_usage;
+} crypto_mechanism_info32_t;
+
+#endif	/* _SYSCALL32 */
+
+extern int crypto_get_all_mech_info(crypto_mech_type_t,
+    crypto_mechanism_info_t **, uint_t *, int);
+extern void crypto_free_all_mech_info(crypto_mechanism_info_t *, uint_t);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_CRYPTO_API_H */

--- a/include/sys/crypto/common.h
+++ b/include/sys/crypto/common.h
@@ -1,0 +1,638 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ */
+
+#ifndef _SYS_CRYPTO_COMMON_H
+#define	_SYS_CRYPTO_COMMON_H
+
+/*
+ * Header file for the common data structures of the cryptographic framework
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/types.h>
+#include <sys/uio.h>
+    // FIXME
+    //#include <sys/stream.h>
+    //#include <sys/mutex.h>
+    //#include <sys/condvar.h>
+
+/* Convenience defines/macros */
+
+#define	CRYPTO_ARG_INPLACE(input, output)	\
+	if ((output) == NULL)		\
+		(output) = (input);
+
+#ifdef _KERNEL
+
+#include <sys/kmem.h>
+#define	CRYPTO_KMFLAG(x)		crypto_kmflag((x))
+#define	CRYPTO_ALLOC(sz, kmflag)	kmem_alloc((sz), (kmflag))
+#define	CRYPTO_ZALLOC(sz, kmflag)	kmem_zalloc((sz), (kmflag))
+#define	CRYPTO_FREE(ptr, sz)		kmem_free((ptr), (sz))
+#define	CRYPTO_ZFREE(ptr, sz)		if (ptr != NULL) { \
+						bzero((ptr), (sz)), \
+						kmem_free((ptr), (sz)); \
+					}
+
+#else	/* _KERNEL */
+
+#include <malloc.h>
+#define	CRYPTO_KMFLAG(x)		(0)
+#define	CRYPTO_ALLOC(sz, kmflag)	malloc((sz))
+#define	CRYPTO_ZALLOC(sz, kmflag)	calloc(1, (sz))
+#define	CRYPTO_FREE(ptr, sz)		free((ptr))
+#define	CRYPTO_ZFREE(ptr, sz)		if (ptr != NULL) { \
+						bzero((ptr), (sz)), \
+						free((ptr)); \
+					}
+
+#endif /* _KERNEL */
+
+/* Cryptographic Mechanisms */
+
+#define	CRYPTO_MAX_MECH_NAME 32
+typedef char crypto_mech_name_t[CRYPTO_MAX_MECH_NAME];
+
+typedef uint64_t crypto_mech_type_t;
+
+typedef struct crypto_mechanism {
+	crypto_mech_type_t	cm_type;	/* mechanism type */
+	caddr_t			cm_param;	/* mech. parameter */
+	size_t			cm_param_len;	/* mech. parameter len */
+} crypto_mechanism_t;
+
+#ifdef  _SYSCALL32
+
+typedef struct crypto_mechanism32 {
+	crypto_mech_type_t	cm_type;	/* mechanism type */
+	caddr32_t		cm_param;	/* mech. parameter */
+	size32_t		cm_param_len;   /* mech. parameter len */
+} crypto_mechanism32_t;
+
+#endif  /* _SYSCALL32 */
+
+#ifdef _KERNEL
+/* CK_AES_CTR_PARAMS provides parameters to the CKM_AES_CTR mechanism */
+typedef struct CK_AES_CTR_PARAMS {
+	ulong_t	ulCounterBits;
+	uint8_t cb[16];
+} CK_AES_CTR_PARAMS;
+#endif
+
+/* CK_AES_CCM_PARAMS provides parameters to the CKM_AES_CCM mechanism */
+typedef struct CK_AES_CCM_PARAMS {
+	ulong_t ulMACSize;
+	ulong_t ulNonceSize;
+	ulong_t ulAuthDataSize;
+	ulong_t ulDataSize; /* used for plaintext or ciphertext */
+	uchar_t *nonce;
+	uchar_t *authData;
+} CK_AES_CCM_PARAMS;
+
+/* CK_AES_GCM_PARAMS provides parameters to the CKM_AES_GCM mechanism */
+typedef struct CK_AES_GCM_PARAMS {
+	uchar_t *pIv;
+	ulong_t ulIvLen;
+	ulong_t ulIvBits;
+	uchar_t *pAAD;
+	ulong_t ulAADLen;
+	ulong_t ulTagBits;
+} CK_AES_GCM_PARAMS;
+
+/* CK_AES_GMAC_PARAMS provides parameters to the CKM_AES_GMAC mechanism */
+typedef struct CK_AES_GMAC_PARAMS {
+	uchar_t *pIv;
+	uchar_t *pAAD;
+	ulong_t ulAADLen;
+} CK_AES_GMAC_PARAMS;
+
+#ifdef _KERNEL
+/*
+ * CK_ECDH1_DERIVE_PARAMS provides the parameters to the
+ * CKM_ECDH1_KEY_DERIVE mechanism
+ */
+typedef struct CK_ECDH1_DERIVE_PARAMS {
+	ulong_t		kdf;
+	ulong_t		ulSharedDataLen;
+	uchar_t		*pSharedData;
+	ulong_t		ulPublicDataLen;
+	uchar_t		*pPublicData;
+} CK_ECDH1_DERIVE_PARAMS;
+#endif
+
+#ifdef _KERNEL
+#ifdef  _SYSCALL32
+
+/* needed for 32-bit applications running on 64-bit kernels */
+typedef struct CK_AES_CTR_PARAMS32 {
+	uint32_t ulCounterBits;
+	uint8_t cb[16];
+} CK_AES_CTR_PARAMS32;
+
+/* needed for 32-bit applications running on 64-bit kernels */
+typedef struct CK_AES_CCM_PARAMS32 {
+	uint32_t ulMACSize;
+	uint32_t ulNonceSize;
+	uint32_t ulAuthDataSize;
+	uint32_t ulDataSize;
+	caddr32_t nonce;
+	caddr32_t authData;
+} CK_AES_CCM_PARAMS32;
+
+/* needed for 32-bit applications running on 64-bit kernels */
+typedef struct CK_AES_GCM_PARAMS32 {
+	caddr32_t pIv;
+	uint32_t ulIvLen;
+	uint32_t ulIvBits;
+	caddr32_t pAAD;
+	uint32_t ulAADLen;
+	uint32_t ulTagBits;
+} CK_AES_GCM_PARAMS32;
+
+/* needed for 32-bit applications running on 64-bit kernels */
+typedef struct CK_AES_GMAC_PARAMS32 {
+	caddr32_t pIv;
+	caddr32_t pAAD;
+	uint32_t ulAADLen;
+} CK_AES_GMAC_PARAMS32;
+
+typedef struct CK_ECDH1_DERIVE_PARAMS32 {
+	uint32_t	kdf;
+	uint32_t	ulSharedDataLen;
+	caddr32_t	pSharedData;
+	uint32_t	ulPublicDataLen;
+	caddr32_t	pPublicData;
+} CK_ECDH1_DERIVE_PARAMS32;
+
+#endif  /* _SYSCALL32 */
+#endif /* _KERNEL */
+
+/*
+ * The measurement unit bit flag for a mechanism's minimum or maximum key size.
+ * The unit are mechanism dependent.  It can be in bits or in bytes.
+ */
+typedef uint32_t crypto_keysize_unit_t;
+
+/*
+ * The following bit flags are valid in cm_mech_flags field in
+ * the crypto_mech_info_t structure of the SPI.
+ *
+ * Only the first two bit flags are valid in mi_keysize_unit
+ * field in the crypto_mechanism_info_t structure of the API.
+ */
+#define	CRYPTO_KEYSIZE_UNIT_IN_BITS	0x00000001
+#define	CRYPTO_KEYSIZE_UNIT_IN_BYTES	0x00000002
+#define	CRYPTO_CAN_SHARE_OPSTATE	0x00000004 /* supports sharing */
+
+
+/* Mechanisms supported out-of-the-box */
+#define	SUN_CKM_MD4			"CKM_MD4"
+#define	SUN_CKM_MD5			"CKM_MD5"
+#define	SUN_CKM_MD5_HMAC		"CKM_MD5_HMAC"
+#define	SUN_CKM_MD5_HMAC_GENERAL	"CKM_MD5_HMAC_GENERAL"
+#define	SUN_CKM_SHA1			"CKM_SHA_1"
+#define	SUN_CKM_SHA1_HMAC		"CKM_SHA_1_HMAC"
+#define	SUN_CKM_SHA1_HMAC_GENERAL	"CKM_SHA_1_HMAC_GENERAL"
+#define	SUN_CKM_SHA256			"CKM_SHA256"
+#define	SUN_CKM_SHA256_HMAC		"CKM_SHA256_HMAC"
+#define	SUN_CKM_SHA256_HMAC_GENERAL	"CKM_SHA256_HMAC_GENERAL"
+#define	SUN_CKM_SHA384			"CKM_SHA384"
+#define	SUN_CKM_SHA384_HMAC		"CKM_SHA384_HMAC"
+#define	SUN_CKM_SHA384_HMAC_GENERAL	"CKM_SHA384_HMAC_GENERAL"
+#define	SUN_CKM_SHA512			"CKM_SHA512"
+#define	SUN_CKM_SHA512_HMAC		"CKM_SHA512_HMAC"
+#define	SUN_CKM_SHA512_HMAC_GENERAL	"CKM_SHA512_HMAC_GENERAL"
+#define	SUN_CKM_DES_CBC			"CKM_DES_CBC"
+#define	SUN_CKM_DES3_CBC		"CKM_DES3_CBC"
+#define	SUN_CKM_DES_ECB			"CKM_DES_ECB"
+#define	SUN_CKM_DES3_ECB		"CKM_DES3_ECB"
+#define	SUN_CKM_BLOWFISH_CBC		"CKM_BLOWFISH_CBC"
+#define	SUN_CKM_BLOWFISH_ECB		"CKM_BLOWFISH_ECB"
+#define	SUN_CKM_AES_CBC			"CKM_AES_CBC"
+#define	SUN_CKM_AES_ECB			"CKM_AES_ECB"
+#define	SUN_CKM_AES_CTR			"CKM_AES_CTR"
+#define	SUN_CKM_AES_CCM			"CKM_AES_CCM"
+#define	SUN_CKM_AES_GCM			"CKM_AES_GCM"
+#define	SUN_CKM_AES_GMAC		"CKM_AES_GMAC"
+#define	SUN_CKM_AES_CFB128		"CKM_AES_CFB128"
+#define	SUN_CKM_RC4			"CKM_RC4"
+#define	SUN_CKM_RSA_PKCS		"CKM_RSA_PKCS"
+#define	SUN_CKM_RSA_X_509		"CKM_RSA_X_509"
+#define	SUN_CKM_MD5_RSA_PKCS		"CKM_MD5_RSA_PKCS"
+#define	SUN_CKM_SHA1_RSA_PKCS		"CKM_SHA1_RSA_PKCS"
+#define	SUN_CKM_SHA256_RSA_PKCS		"CKM_SHA256_RSA_PKCS"
+#define	SUN_CKM_SHA384_RSA_PKCS		"CKM_SHA384_RSA_PKCS"
+#define	SUN_CKM_SHA512_RSA_PKCS		"CKM_SHA512_RSA_PKCS"
+#define	SUN_CKM_EC_KEY_PAIR_GEN		"CKM_EC_KEY_PAIR_GEN"
+#define	SUN_CKM_ECDH1_DERIVE		"CKM_ECDH1_DERIVE"
+#define	SUN_CKM_ECDSA_SHA1		"CKM_ECDSA_SHA1"
+#define	SUN_CKM_ECDSA			"CKM_ECDSA"
+
+/* Shared operation context format for CKM_RC4 */
+typedef struct {
+#if defined(__amd64)
+	uint32_t	i, j;
+	uint32_t	arr[256];
+	uint32_t	flag;
+#else
+	uchar_t		arr[256];
+	uchar_t		i, j;
+#endif /* __amd64 */
+	uint64_t	pad;		/* For 64-bit alignment */
+} arcfour_state_t;
+
+/* Data arguments of cryptographic operations */
+
+typedef enum crypto_data_format {
+	CRYPTO_DATA_RAW = 1,
+	CRYPTO_DATA_UIO,
+	CRYPTO_DATA_MBLK
+} crypto_data_format_t;
+
+typedef struct crypto_data {
+	crypto_data_format_t	cd_format;	/* Format identifier	*/
+	off_t			cd_offset;	/* Offset from the beginning */
+	size_t			cd_length;	/* # of bytes in use */
+	caddr_t			cd_miscdata;	/* ancillary data */
+	union {
+		/* Raw format */
+		iovec_t cdu_raw;		/* Pointer and length	    */
+
+		/* uio scatter-gather format */
+		uio_t	*cdu_uio;
+
+		/* mblk scatter-gather format */
+        // FIXME
+		//mblk_t	*cdu_mp;		/* The mblk chain */
+
+	} cdu;	/* Crypto Data Union */
+} crypto_data_t;
+
+#define	cd_raw		cdu.cdu_raw
+#define	cd_uio		cdu.cdu_uio
+#define	cd_mp		cdu.cdu_mp
+
+#define	CRYPTO_SET_RAW_DATA(var, str, len)	\
+	(var).cd_format = CRYPTO_DATA_RAW;	\
+	(var).cd_offset = 0;			\
+	(var).cd_length = (len);		\
+	(var).cd_miscdata = NULL;		\
+	(var).cd_raw.iov_base = (caddr_t)(str);	\
+	(var).cd_raw.iov_len = (len);
+
+#define	CRYPTO_DATA_IS_USERSPACE(buf) \
+	((buf->cd_format == CRYPTO_DATA_UIO && \
+	buf->cd_uio->uio_segflg == UIO_USERSPACE))
+
+typedef struct crypto_dual_data {
+	crypto_data_t		dd_data;	/* The data */
+	off_t			dd_offset2;	/* Used by dual operation */
+	size_t			dd_len2;	/* # of bytes to take	*/
+} crypto_dual_data_t;
+
+#define	dd_format	dd_data.cd_format
+#define	dd_offset1	dd_data.cd_offset
+#define	dd_len1		dd_data.cd_length
+#define	dd_miscdata	dd_data.cd_miscdata
+#define	dd_raw		dd_data.cd_raw
+#define	dd_uio		dd_data.cd_uio
+#define	dd_mp		dd_data.cd_mp
+
+/* The keys, and their contents */
+
+typedef enum {
+	CRYPTO_KEY_RAW = 1,	/* ck_data is a cleartext key */
+	CRYPTO_KEY_REFERENCE,	/* ck_obj_id is an opaque reference */
+	CRYPTO_KEY_ATTR_LIST	/* ck_attrs is a list of object attributes */
+} crypto_key_format_t;
+
+typedef uint64_t crypto_attr_type_t;
+
+/* Attribute types to use for passing a RSA public key or a private key. */
+#define	SUN_CKA_MODULUS			0x00000120
+#define	SUN_CKA_MODULUS_BITS		0x00000121
+#define	SUN_CKA_PUBLIC_EXPONENT		0x00000122
+#define	SUN_CKA_PRIVATE_EXPONENT	0x00000123
+#define	SUN_CKA_PRIME_1			0x00000124
+#define	SUN_CKA_PRIME_2			0x00000125
+#define	SUN_CKA_EXPONENT_1		0x00000126
+#define	SUN_CKA_EXPONENT_2		0x00000127
+#define	SUN_CKA_COEFFICIENT		0x00000128
+#define	SUN_CKA_PRIME			0x00000130
+#define	SUN_CKA_SUBPRIME		0x00000131
+#define	SUN_CKA_BASE			0x00000132
+
+#define	CKK_EC			0x00000003
+#define	CKK_GENERIC_SECRET	0x00000010
+#define	CKK_RC4			0x00000012
+#define	CKK_AES			0x0000001F
+#define	CKK_DES			0x00000013
+#define	CKK_DES2		0x00000014
+#define	CKK_DES3		0x00000015
+
+#define	CKO_PUBLIC_KEY		0x00000002
+#define	CKO_PRIVATE_KEY		0x00000003
+#define	CKA_CLASS		0x00000000
+#define	CKA_VALUE		0x00000011
+#define	CKA_KEY_TYPE		0x00000100
+#define	CKA_VALUE_LEN		0x00000161
+#define	CKA_EC_PARAMS		0x00000180
+#define	CKA_EC_POINT		0x00000181
+
+typedef uint32_t	crypto_object_id_t;
+
+typedef struct crypto_object_attribute {
+	crypto_attr_type_t	oa_type;	/* attribute type */
+	caddr_t			oa_value;	/* attribute value */
+	ssize_t			oa_value_len;	/* length of attribute value */
+} crypto_object_attribute_t;
+
+typedef struct crypto_key {
+	crypto_key_format_t	ck_format;	/* format identifier */
+	union {
+		/* for CRYPTO_KEY_RAW ck_format */
+		struct {
+			uint_t	cku_v_length;	/* # of bits in ck_data   */
+			void	*cku_v_data;	/* ptr to key value */
+		} cku_key_value;
+
+		/* for CRYPTO_KEY_REFERENCE ck_format */
+		crypto_object_id_t cku_key_id;	/* reference to object key */
+
+		/* for CRYPTO_KEY_ATTR_LIST ck_format */
+		struct {
+			uint_t cku_a_count;	/* number of attributes */
+			crypto_object_attribute_t *cku_a_oattr;
+		} cku_key_attrs;
+	} cku_data;				/* Crypto Key union */
+} crypto_key_t;
+
+#ifdef  _SYSCALL32
+
+typedef struct crypto_object_attribute32 {
+	uint64_t	oa_type;	/* attribute type */
+	caddr32_t	oa_value;	/* attribute value */
+	ssize32_t	oa_value_len;	/* length of attribute value */
+} crypto_object_attribute32_t;
+
+typedef struct crypto_key32 {
+	crypto_key_format_t	ck_format;	/* format identifier */
+	union {
+		/* for CRYPTO_KEY_RAW ck_format */
+		struct {
+			uint32_t cku_v_length;	/* # of bytes in ck_data */
+			caddr32_t cku_v_data;	/* ptr to key value */
+		} cku_key_value;
+
+		/* for CRYPTO_KEY_REFERENCE ck_format */
+		crypto_object_id_t cku_key_id; /* reference to object key */
+
+		/* for CRYPTO_KEY_ATTR_LIST ck_format */
+		struct {
+			uint32_t cku_a_count;	/* number of attributes */
+			caddr32_t cku_a_oattr;
+		} cku_key_attrs;
+	} cku_data;				/* Crypto Key union */
+} crypto_key32_t;
+
+#endif  /* _SYSCALL32 */
+
+#define	ck_data		cku_data.cku_key_value.cku_v_data
+#define	ck_length	cku_data.cku_key_value.cku_v_length
+#define	ck_obj_id	cku_data.cku_key_id
+#define	ck_count	cku_data.cku_key_attrs.cku_a_count
+#define	ck_attrs	cku_data.cku_key_attrs.cku_a_oattr
+
+/*
+ * Raw key lengths are expressed in number of bits.
+ * The following macro returns the minimum number of
+ * bytes that can contain the specified number of bits.
+ * Round up without overflowing the integer type.
+ */
+#define	CRYPTO_BITS2BYTES(n) ((n) == 0 ? 0 : (((n) - 1) >> 3) + 1)
+#define	CRYPTO_BYTES2BITS(n) ((n) << 3)
+
+/* Providers */
+
+typedef enum {
+	CRYPTO_HW_PROVIDER = 0,
+	CRYPTO_SW_PROVIDER,
+	CRYPTO_LOGICAL_PROVIDER
+} crypto_provider_type_t;
+
+typedef uint32_t 	crypto_provider_id_t;
+#define	KCF_PROVID_INVALID	((uint32_t)-1)
+
+typedef struct crypto_provider_entry {
+	crypto_provider_id_t	pe_provider_id;
+	uint_t			pe_mechanism_count;
+} crypto_provider_entry_t;
+
+typedef struct crypto_dev_list_entry {
+	char			le_dev_name[MAXNAMELEN];
+	uint_t			le_dev_instance;
+	uint_t			le_mechanism_count;
+} crypto_dev_list_entry_t;
+
+/* User type for authentication ioctls and SPI entry points */
+
+typedef enum crypto_user_type {
+	CRYPTO_SO = 0,
+	CRYPTO_USER
+} crypto_user_type_t;
+
+/* Version for provider management ioctls and SPI entry points */
+
+typedef struct crypto_version {
+	uchar_t	cv_major;
+	uchar_t	cv_minor;
+} crypto_version_t;
+
+/* session data structure opaque to the consumer */
+typedef void *crypto_session_t;
+
+/* provider data structure opaque to the consumer */
+typedef void *crypto_provider_t;
+
+/* Limits used by both consumers and providers */
+#define	CRYPTO_EXT_SIZE_LABEL		32
+#define	CRYPTO_EXT_SIZE_MANUF		32
+#define	CRYPTO_EXT_SIZE_MODEL		16
+#define	CRYPTO_EXT_SIZE_SERIAL		16
+#define	CRYPTO_EXT_SIZE_TIME		16
+
+typedef struct crypto_provider_ext_info {
+	uchar_t			ei_label[CRYPTO_EXT_SIZE_LABEL];
+	uchar_t			ei_manufacturerID[CRYPTO_EXT_SIZE_MANUF];
+	uchar_t			ei_model[CRYPTO_EXT_SIZE_MODEL];
+	uchar_t			ei_serial_number[CRYPTO_EXT_SIZE_SERIAL];
+	ulong_t			ei_flags;
+	ulong_t			ei_max_session_count;
+	ulong_t			ei_max_pin_len;
+	ulong_t			ei_min_pin_len;
+	ulong_t			ei_total_public_memory;
+	ulong_t			ei_free_public_memory;
+	ulong_t			ei_total_private_memory;
+	ulong_t			ei_free_private_memory;
+	crypto_version_t	ei_hardware_version;
+	crypto_version_t	ei_firmware_version;
+	uchar_t			ei_time[CRYPTO_EXT_SIZE_TIME];
+	int			ei_hash_max_input_len;
+	int			ei_hmac_max_input_len;
+} crypto_provider_ext_info_t;
+
+typedef uint_t		crypto_session_id_t;
+
+typedef enum cmd_type {
+	COPY_FROM_DATA,
+	COPY_TO_DATA,
+	COMPARE_TO_DATA,
+	MD5_DIGEST_DATA,
+	SHA1_DIGEST_DATA,
+	SHA2_DIGEST_DATA,
+	GHASH_DATA
+} cmd_type_t;
+
+#define	CRYPTO_DO_UPDATE	0x01
+#define	CRYPTO_DO_FINAL		0x02
+#define	CRYPTO_DO_MD5		0x04
+#define	CRYPTO_DO_SHA1		0x08
+#define	CRYPTO_DO_SIGN		0x10
+#define	CRYPTO_DO_VERIFY	0x20
+#define	CRYPTO_DO_SHA2		0x40
+
+#define	PROVIDER_OWNS_KEY_SCHEDULE	0x00000001
+
+/*
+ * Common cryptographic status and error codes.
+ */
+#define	CRYPTO_SUCCESS				0x00000000
+#define	CRYPTO_CANCEL				0x00000001
+#define	CRYPTO_HOST_MEMORY			0x00000002
+#define	CRYPTO_GENERAL_ERROR			0x00000003
+#define	CRYPTO_FAILED				0x00000004
+#define	CRYPTO_ARGUMENTS_BAD			0x00000005
+#define	CRYPTO_ATTRIBUTE_READ_ONLY		0x00000006
+#define	CRYPTO_ATTRIBUTE_SENSITIVE		0x00000007
+#define	CRYPTO_ATTRIBUTE_TYPE_INVALID		0x00000008
+#define	CRYPTO_ATTRIBUTE_VALUE_INVALID		0x00000009
+#define	CRYPTO_CANCELED				0x0000000A
+#define	CRYPTO_DATA_INVALID			0x0000000B
+#define	CRYPTO_DATA_LEN_RANGE			0x0000000C
+#define	CRYPTO_DEVICE_ERROR			0x0000000D
+#define	CRYPTO_DEVICE_MEMORY			0x0000000E
+#define	CRYPTO_DEVICE_REMOVED			0x0000000F
+#define	CRYPTO_ENCRYPTED_DATA_INVALID		0x00000010
+#define	CRYPTO_ENCRYPTED_DATA_LEN_RANGE		0x00000011
+#define	CRYPTO_KEY_HANDLE_INVALID		0x00000012
+#define	CRYPTO_KEY_SIZE_RANGE			0x00000013
+#define	CRYPTO_KEY_TYPE_INCONSISTENT		0x00000014
+#define	CRYPTO_KEY_NOT_NEEDED			0x00000015
+#define	CRYPTO_KEY_CHANGED			0x00000016
+#define	CRYPTO_KEY_NEEDED			0x00000017
+#define	CRYPTO_KEY_INDIGESTIBLE			0x00000018
+#define	CRYPTO_KEY_FUNCTION_NOT_PERMITTED	0x00000019
+#define	CRYPTO_KEY_NOT_WRAPPABLE		0x0000001A
+#define	CRYPTO_KEY_UNEXTRACTABLE		0x0000001B
+#define	CRYPTO_MECHANISM_INVALID		0x0000001C
+#define	CRYPTO_MECHANISM_PARAM_INVALID		0x0000001D
+#define	CRYPTO_OBJECT_HANDLE_INVALID		0x0000001E
+#define	CRYPTO_OPERATION_IS_ACTIVE		0x0000001F
+#define	CRYPTO_OPERATION_NOT_INITIALIZED	0x00000020
+#define	CRYPTO_PIN_INCORRECT			0x00000021
+#define	CRYPTO_PIN_INVALID			0x00000022
+#define	CRYPTO_PIN_LEN_RANGE			0x00000023
+#define	CRYPTO_PIN_EXPIRED			0x00000024
+#define	CRYPTO_PIN_LOCKED			0x00000025
+#define	CRYPTO_SESSION_CLOSED			0x00000026
+#define	CRYPTO_SESSION_COUNT			0x00000027
+#define	CRYPTO_SESSION_HANDLE_INVALID		0x00000028
+#define	CRYPTO_SESSION_READ_ONLY		0x00000029
+#define	CRYPTO_SESSION_EXISTS			0x0000002A
+#define	CRYPTO_SESSION_READ_ONLY_EXISTS		0x0000002B
+#define	CRYPTO_SESSION_READ_WRITE_SO_EXISTS	0x0000002C
+#define	CRYPTO_SIGNATURE_INVALID		0x0000002D
+#define	CRYPTO_SIGNATURE_LEN_RANGE		0x0000002E
+#define	CRYPTO_TEMPLATE_INCOMPLETE		0x0000002F
+#define	CRYPTO_TEMPLATE_INCONSISTENT		0x00000030
+#define	CRYPTO_UNWRAPPING_KEY_HANDLE_INVALID	0x00000031
+#define	CRYPTO_UNWRAPPING_KEY_SIZE_RANGE	0x00000032
+#define	CRYPTO_UNWRAPPING_KEY_TYPE_INCONSISTENT	0x00000033
+#define	CRYPTO_USER_ALREADY_LOGGED_IN		0x00000034
+#define	CRYPTO_USER_NOT_LOGGED_IN		0x00000035
+#define	CRYPTO_USER_PIN_NOT_INITIALIZED		0x00000036
+#define	CRYPTO_USER_TYPE_INVALID		0x00000037
+#define	CRYPTO_USER_ANOTHER_ALREADY_LOGGED_IN	0x00000038
+#define	CRYPTO_USER_TOO_MANY_TYPES		0x00000039
+#define	CRYPTO_WRAPPED_KEY_INVALID		0x0000003A
+#define	CRYPTO_WRAPPED_KEY_LEN_RANGE		0x0000003B
+#define	CRYPTO_WRAPPING_KEY_HANDLE_INVALID	0x0000003C
+#define	CRYPTO_WRAPPING_KEY_SIZE_RANGE		0x0000003D
+#define	CRYPTO_WRAPPING_KEY_TYPE_INCONSISTENT	0x0000003E
+#define	CRYPTO_RANDOM_SEED_NOT_SUPPORTED	0x0000003F
+#define	CRYPTO_RANDOM_NO_RNG			0x00000040
+#define	CRYPTO_DOMAIN_PARAMS_INVALID		0x00000041
+#define	CRYPTO_BUFFER_TOO_SMALL			0x00000042
+#define	CRYPTO_INFORMATION_SENSITIVE		0x00000043
+#define	CRYPTO_NOT_SUPPORTED			0x00000044
+
+#define	CRYPTO_QUEUED				0x00000045
+#define	CRYPTO_BUFFER_TOO_BIG			0x00000046
+#define	CRYPTO_INVALID_CONTEXT			0x00000047
+#define	CRYPTO_INVALID_MAC			0x00000048
+#define	CRYPTO_MECH_NOT_SUPPORTED		0x00000049
+#define	CRYPTO_INCONSISTENT_ATTRIBUTE		0x0000004A
+#define	CRYPTO_NO_PERMISSION			0x0000004B
+#define	CRYPTO_INVALID_PROVIDER_ID		0x0000004C
+#define	CRYPTO_VERSION_MISMATCH			0x0000004D
+#define	CRYPTO_BUSY				0x0000004E
+#define	CRYPTO_UNKNOWN_PROVIDER			0x0000004F
+#define	CRYPTO_MODVERIFICATION_FAILED		0x00000050
+#define	CRYPTO_OLD_CTX_TEMPLATE			0x00000051
+#define	CRYPTO_WEAK_KEY				0x00000052
+#define	CRYPTO_FIPS140_ERROR			0x00000053
+/*
+ * Don't forget to update CRYPTO_LAST_ERROR and the error_number_table[]
+ * in kernelUtil.c when new error code is added.
+ */
+#define	CRYPTO_LAST_ERROR			0x00000053
+
+/*
+ * Special values that can be used to indicate that information is unavailable
+ * or that there is not practical limit. These values can be used
+ * by fields of the SPI crypto_provider_ext_info(9S) structure.
+ * The value of CRYPTO_UNAVAILABLE_INFO should be the same as
+ * CK_UNAVAILABLE_INFO in the PKCS#11 spec.
+ */
+#define	CRYPTO_UNAVAILABLE_INFO		((ulong_t)(-1))
+#define	CRYPTO_EFFECTIVELY_INFINITE	0x0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_CRYPTO_COMMON_H */

--- a/module/spl/Makefile.in
+++ b/module/spl/Makefile.in
@@ -25,3 +25,4 @@ $(MODULE)-objs += @top_srcdir@/module/spl/spl-xdr.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-cred.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-tsd.o
 $(MODULE)-objs += @top_srcdir@/module/spl/spl-zlib.o
+$(MODULE)-objs += @top_srcdir@/module/spl/spl-crypto.o

--- a/module/spl/spl-crypto.c
+++ b/module/spl/spl-crypto.c
@@ -1,0 +1,612 @@
+#include <sys/crypto/api.h>
+#include <sys/cmn_err.h>
+
+#include <linux/scatterlist.h>
+#include <linux/crypto.h>
+
+
+int crypto_mac(crypto_mechanism_t *mech, crypto_data_t *data,
+               crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *mac,
+               crypto_call_req_t *cr)
+{
+#if _KERNEL
+    printk("crypto_mac\n");
+#endif
+    return 0;
+}
+
+
+
+int crypto_decryptX(crypto_mechanism_t *mech, crypto_data_t *ciphertext,
+                   crypto_key_t *key, crypto_ctx_template_t tmpl,
+                   crypto_data_t *plaintext, crypto_call_req_t *cr)
+{
+#if _KERNEL
+    unsigned char *src;
+    unsigned char *dst;
+    size_t len = 0;
+    int i;
+
+    if (ciphertext->cd_format != CRYPTO_DATA_RAW) {
+        printk("crypto_decrypt  cd_format is NOT RAW?! %d\n", ciphertext->cd_format);
+        return -1;
+    }
+
+    if (plaintext && plaintext->cd_format != CRYPTO_DATA_RAW) {
+        printk("crypto_decrypt  cd_format is NOT RAW?! %d\n", plaintext->cd_format);
+        return -1;
+    }
+
+    src = (unsigned char *)ciphertext->cd_raw.iov_base;
+    len = (size_t) ciphertext->cd_raw.iov_len;
+
+    if (plaintext && plaintext->cd_raw.iov_base)
+        dst = (unsigned char *)plaintext->cd_raw.iov_base;
+    else
+        dst = src;
+
+    printk("crypto_decrypt (%p -> %p) 0x%04lx\n",
+           src, dst, (unsigned long)len);
+
+    for (i = 0; i < len; i++)
+        //dst[i] = isalpha(src[i]) ? src[i]^0x20 : src[i];
+        dst[i] = src[i];
+
+    // Notify caller.
+    if (cr && cr->cr_callback_func) {
+        printk("   notifying caller\n");
+        cr->cr_callback_func(cr->cr_callback_arg, cr->cr_reqid);
+        return CRYPTO_QUEUED;
+    }
+
+#endif
+    return CRYPTO_SUCCESS;
+}
+
+int crypto_decryptXXX(crypto_mechanism_t *mech, crypto_data_t *ciphertext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *plaintext,
+    crypto_call_req_t *cr)
+{
+#if _KERNEL
+    unsigned char *src;
+    unsigned char *dst;
+    size_t len = 0;
+    int i;
+    unsigned int numiov = 0, curriov = 0, iovlen = 0;
+    uio_t *srcuio = NULL;
+    iovec_t *srciov = NULL;
+
+    // Decrypt, we will get UIO -> RAW
+    printk("crypto_decrypt  ciphertext cd_format %d, plaintext %d\n",
+           ciphertext->cd_format, plaintext->cd_format);
+
+    // DST is always RAW
+    if (plaintext->cd_format != CRYPTO_DATA_RAW) {
+        printk("crypto_decrypt  cd_format is NOT RAW?! %d\n", plaintext->cd_format);
+        return CRYPTO_FAILED;
+    }
+
+    // SRC can be RAW, or UIO
+    if ((plaintext->cd_format == CRYPTO_DATA_UIO) &&
+        (plaintext->cd_uio->uio_segflg == UIO_USERSPACE)) {
+        printk("crypto_decrypt  cipher cd_format is UIO?! segment is %s!!!\n",
+               ciphertext->cd_uio->uio_segflg == UIO_USERSPACE ? "user" : "system");
+        return CRYPTO_FAILED;
+    }
+
+    // We dont support MBLK at all
+    if (plaintext->cd_format == CRYPTO_DATA_MBLK) {
+        printk("crypto_decrypt  cipher cd_format is MBLK?!\n");
+        return CRYPTO_FAILED;
+    }
+
+    // We do not handle callbacks (so far they've not been needed)
+    if (cr != NULL) {
+      printk("crypto_decrypt with callback request not supported\n");
+      return CRYPTO_FAILED;
+    }
+
+    dst = (unsigned char *)plaintext->cd_raw.iov_base;
+    len = (size_t) plaintext->cd_length;
+
+    if (ciphertext && ciphertext->cd_raw.iov_base)
+        src = (unsigned char *)ciphertext->cd_raw.iov_base;
+    else
+        src = dst;
+
+    if (ciphertext->cd_format == CRYPTO_DATA_UIO) {
+      srcuio = ciphertext->cd_uio;
+      numiov = srcuio->uio_iovcnt;
+      curriov = 0;
+      iovlen = 0; // Forces read of first iov.
+      srciov = srcuio->uio_iov;
+      printk("crypto_decrypt: UIO :  with %u iovs: total 0x%04lx/0x%04lx\n",
+             numiov,
+             (unsigned long)len,
+             (unsigned long)plaintext->cd_raw.iov_len);
+    }
+
+    if (numiov == 0) {
+      printk("crypto_decrypt (%p -> %p) 0x%04lx/0x%04lx (offset 0x%04lx: numiov %u)\n",
+	     src, dst,
+             (unsigned long)len,
+             (unsigned long)plaintext->cd_raw.iov_len,
+             (unsigned long)plaintext->cd_offset,
+             numiov);
+    }
+
+    for (i = 0; i < len; i++) {
+
+        if (numiov && !iovlen) { // uses UIO, and ran out of space, move to next
+
+            src = srciov[ curriov ].iov_base;
+            iovlen = srciov[ curriov ].iov_len;
+
+            printk("crypto_decrypt IOV (%p -> %p) curriov %u, iovlen 0x%04lx\n",
+                   src, dst, curriov, (unsigned long)iovlen);
+
+            curriov++; // Ready next.
+            if (curriov >= numiov) { // out of dst space
+                if (i < len) printk("crypto_decrypt ran outof dst space before src i=%d\n", i);
+                break;
+            }
+        } // if numiov
+
+        // ENCRYPT!
+        dst[i] = isalpha(src[i]) ? src[i]^0x20 : src[i];
+        // dst[i] = src[i];
+
+        // Decrease UIO, if used
+        if (iovlen) iovlen--;
+    }
+
+    printk("crypto_decrypt: done\n");
+    return CRYPTO_SUCCESS;
+#endif
+    ASSERT(1==0);
+    return CRYPTO_FAILED;
+}
+
+
+// So far, ZFS-crypto only uses 2 buffers. data + mac
+#define SPL_CRYPTO_MAX_BUF 2
+
+
+size_t crypto_map_buffers(crypto_data_t *solaris_buffer,
+                       struct scatterlist linux_buffer[SPL_CRYPTO_MAX_BUF])
+{
+    uio_t *uio = NULL;
+    iovec_t *iov = NULL;
+    int i;
+    size_t len = 0;
+
+    // Setup SOURCE buffer(s)
+    switch(solaris_buffer->cd_format) {
+    case CRYPTO_DATA_RAW: // One buffer.
+        sg_init_table(linux_buffer, 1 );
+        sg_set_buf(&linux_buffer[0],
+                   solaris_buffer->cd_raw.iov_base, // srcptr
+                   solaris_buffer->cd_length);      // srclen
+        printk("spl-crypto: mapping buffer to RAW->1 %p len 0x%04lx.\n",
+               solaris_buffer->cd_raw.iov_base, solaris_buffer->cd_length);
+        return solaris_buffer->cd_length;
+
+    case CRYPTO_DATA_UIO: // Multiple buffers.
+        uio = solaris_buffer->cd_uio;
+        iov = uio->uio_iov;
+        ASSERT( uio->uio_iovcnt <= SPL_CRYPTO_MAX_BUF );
+        sg_init_table(linux_buffer, uio->uio_iovcnt );
+        for (i = 0; i < uio->uio_iovcnt; i++) {
+            sg_set_buf(&linux_buffer[i],
+                        iov[i].iov_base,
+                        iov[i].iov_len);
+            printk("spl-crypto: mapping buffer %d to UIO->%d. %p len 0x%04lx\n",
+                   i, uio->uio_iovcnt, iov[i].iov_base, iov[i].iov_len );
+            len += iov[i].iov_len;
+        }
+        return len;
+
+    case CRYPTO_DATA_MBLK: // network mbufs
+    default:
+        cmn_err(CE_PANIC, "spl-crypto: map->cd_format of unsupported type=%d",
+                solaris_buffer->cd_format);
+        return 0;
+
+    }
+}
+
+struct tcrypt_result {
+	struct completion completion;
+	int err;
+};
+
+static void spl_async_cipher_done(struct crypto_async_request *req, int err)
+{
+	struct tcrypt_result *res = req->data;
+
+    printk("cipher_work_done called: %d\n", err);
+
+	if (err == -EINPROGRESS)
+		return;
+
+	res->err = err;
+	complete(&res->completion);
+}
+
+
+void spl_crypto_map_iv(unsigned char *iv, int len, void *param)
+{
+    CK_AES_CCM_PARAMS *ccm_param = (CK_AES_CCM_PARAMS *)param;
+
+    ASSERT(ccm_param != NULL);
+
+    // 'iv' is set as, from Solaris kernel sources;
+    // In ZFS-crypt, the "nonceSize" is always 12.
+    // q = (uint8_t)((15 - nonceSize) & 0xFF);
+    // cb[0] = 0x07 & (q-1);
+    // cb[1..12] = supplied nonce
+    // cb[13..14] = 0
+    // cb[15] = 1;
+    memset(iv, 0, len); // Make all bytes 0 first.
+    iv[0]  = 0x02;
+    memcpy(&iv[1], ccm_param->nonce, ccm_param->ulNonceSize); // 12 bytes
+    iv[15] = 0x01;
+
+}
+
+//
+// Wrapper call from Solaris API, to Linux API.
+//
+// We convert Solaris crypto_data_t pointers (including the multi-buffer UIO)
+// into Linux scatterlist buffer(s).
+//
+int crypto_encrypt(crypto_mechanism_t *mech, crypto_data_t *plaintext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *ciphertext,
+    crypto_call_req_t *cr)
+{
+#if _KERNEL
+    int ret = CRYPTO_FAILED;
+    struct crypto_aead  *tfm = NULL;
+    struct aead_request *req = NULL;
+    struct tcrypt_result result;
+    struct scatterlist linux_plain[SPL_CRYPTO_MAX_BUF];
+    struct scatterlist linux_cipher[SPL_CRYPTO_MAX_BUF];
+    size_t plainlen = 0, cryptlen = 0, maclen = 0;
+    unsigned char iv[16];
+    unsigned char assoc[16];
+    struct scatterlist assoctext[1];
+
+    printk("spl-crypto: enter\n");
+
+    ASSERT(mech != NULL);
+
+    // We don't use assoc, but it appears it needs to be supplied.
+    memset(assoc, 0, sizeof(assoc));
+    sg_init_one(&assoctext[0], assoc, sizeof(assoc));
+
+    ASSERT(key->ck_format == CRYPTO_KEY_RAW);
+
+    // Use source len as cryptolen.
+    if (!(plainlen = crypto_map_buffers(plaintext, linux_plain)))
+        return CRYPTO_FAILED;
+    if (!(cryptlen = crypto_map_buffers(ciphertext, linux_cipher)))
+        return CRYPTO_FAILED;
+
+    // What is the size of the MAC buffer?
+    maclen = cryptlen - plainlen;
+
+    printk("spl-crypto: buffers set, len 0x%04lx / 0x%04lx (mac %ld)\n",
+           plainlen, cryptlen, maclen);
+
+    // This gets us a valid cipher, but the MAC differs from Solaris 'mac(sha256)'
+    tfm = crypto_alloc_aead("ccm(aes)", 0, 0);
+    if (IS_ERR(tfm)) return CRYPTO_FAILED;
+
+    printk("spl-crypto: aead alloc OK\n");
+
+    req = aead_request_alloc(tfm, GFP_KERNEL);
+    if (!req) goto out;
+
+    printk("spl-crypto: req alloc OK\n");
+
+    crypto_aead_setkey(tfm,
+                       key->ck_data,
+                       key->ck_length / 8);
+
+    spl_crypto_map_iv(iv, sizeof(iv), mech->cm_param);
+
+    // If ASYNC is used.
+    init_completion(&result.completion);
+    aead_request_set_callback(req, CRYPTO_TFM_REQ_MAY_BACKLOG,
+                              spl_async_cipher_done, &result);
+
+    aead_request_set_crypt(req, linux_plain, linux_cipher, plainlen, iv);
+    aead_request_set_assoc(req, assoctext, sizeof(assoc));
+    crypto_aead_setauthsize(tfm, maclen);
+
+    printk("spl-crypto: calling encrypt(0x%04lx)\n", plainlen);
+
+    ret = crypto_aead_encrypt(req);
+
+    switch(ret) {
+    case 0: // Success, immedate return
+        ret = CRYPTO_SUCCESS;
+        break;
+
+    case -EINPROGRESS: // Async call, wait for completion
+    case -EBUSY:
+        ret = wait_for_completion_interruptible(
+                                                &result.completion);
+        if (!ret && !(ret = result.err)) {
+            INIT_COMPLETION(result.completion);
+            break;
+        }
+        break;
+
+    default:
+        cmn_err(CE_WARN, "spl-crypto: encrypt failed: %d", ret);
+        break;
+    }
+
+ out:
+    if (req) aead_request_free(req);
+    if (!IS_ERR(tfm)) crypto_free_aead(tfm);
+
+    printk("spl-crypto: encrypt done: ret %d\n", ret);
+    return ret;
+#endif
+    ASSERT(1==0);
+    return CRYPTO_FAILED;
+}
+
+
+
+int crypto_decrypt(crypto_mechanism_t *mech, crypto_data_t *ciphertext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *plaintext,
+    crypto_call_req_t *cr)
+{
+#if _KERNEL
+    int ret = CRYPTO_FAILED;
+    struct crypto_aead  *tfm = NULL;
+    struct aead_request *req = NULL;
+    struct tcrypt_result result;
+    struct scatterlist linux_plain[SPL_CRYPTO_MAX_BUF];
+    struct scatterlist linux_cipher[SPL_CRYPTO_MAX_BUF];
+    size_t cryptlen = 0, plainlen = 0, maclen = 0;
+    unsigned char iv[16];
+    unsigned char assoc[16];
+    struct scatterlist assoctext[1];
+
+    printk("spl-crypto: decrypt enter\n");
+
+    ASSERT(mech != NULL);
+
+    // We don't use assoc, but it appears it needs to be supplied.
+    memset(assoc, 0, sizeof(assoc));
+    sg_init_one(&assoctext[0], assoc, sizeof(assoc));
+
+    ASSERT(key->ck_format == CRYPTO_KEY_RAW);
+
+    // Use source len as cryptolen. If we are given two buffers here,
+    // the cryptolen should be msglen + maclen. ie, 512 + 16, which
+    // is what linux_decrypt expects to get
+    if (!(plainlen = crypto_map_buffers(plaintext, linux_plain)))
+        return CRYPTO_FAILED;
+    if (!(cryptlen = crypto_map_buffers(ciphertext, linux_cipher)))
+        return CRYPTO_FAILED;
+
+    maclen = cryptlen - plainlen;
+
+    printk("spl-crypto: buffers set, len 0x%04lx / 0x%04lx (mac %ld)\n",
+           plainlen, cryptlen, maclen);
+
+    // This gets us a valid cipher, but the MAC differs from Solaris 'mac(sha256)'
+    tfm = crypto_alloc_aead("ccm(aes)", 0, 0);
+    if (IS_ERR(tfm)) return CRYPTO_FAILED;
+
+    req = aead_request_alloc(tfm, GFP_KERNEL);
+    if (!req) goto out;
+
+    crypto_aead_setkey(tfm,
+                       key->ck_data,
+                       key->ck_length / 8);
+
+    spl_crypto_map_iv(iv, sizeof(iv), mech->cm_param);
+
+    // If ASYNC is used.
+    init_completion(&result.completion);
+    aead_request_set_callback(req, CRYPTO_TFM_REQ_MAY_BACKLOG,
+                              spl_async_cipher_done, &result);
+
+    aead_request_set_crypt(req, linux_cipher, linux_plain, cryptlen, iv);
+    aead_request_set_assoc(req, assoctext, sizeof(assoc));
+    crypto_aead_setauthsize(tfm, maclen);
+
+    printk("spl-crypt: calling decrypt(0x%04lx / 0x%04lx maclen %ld)\n",
+           plainlen, cryptlen, maclen);
+
+    ret = crypto_aead_decrypt(req);
+
+    switch(ret) {
+    case 0: // Success, immedate return
+        ret = CRYPTO_SUCCESS;
+        break;
+
+    case -EINPROGRESS: // Async call, wait for completion
+    case -EBUSY:
+        ret = wait_for_completion_interruptible(
+                                                &result.completion);
+        if (!ret && !(ret = result.err)) {
+            INIT_COMPLETION(result.completion);
+            break;
+        }
+        break;
+
+    case EBADMSG: // Verify authenticate failed.
+        cmn_err(CE_WARN, "spl-crypto: decrypt verify failed.");
+        ret = CRYPTO_SUCCESS;
+        break;
+
+    default:
+        cmn_err(CE_WARN, "spl-crypto: decrypt failed: %d", ret);
+        break;
+    }
+
+ out:
+    if (req) aead_request_free(req);
+    if (!IS_ERR(tfm)) crypto_free_aead(tfm);
+
+    printk("spl-crypto: decrypt done.\n");
+    return ret;
+#endif
+    ASSERT(1==0);
+    return CRYPTO_FAILED;
+}
+
+
+
+
+
+
+
+
+int crypto_encryptOLD(crypto_mechanism_t *mech, crypto_data_t *plaintext,
+    crypto_key_t *key, crypto_ctx_template_t tmpl, crypto_data_t *ciphertext,
+    crypto_call_req_t *cr)
+{
+#if _KERNEL
+    unsigned char *src;
+    unsigned char *dst;
+    size_t len = 0;
+    int i;
+    unsigned int numiov = 0, curriov = 0, iovlen = 0;
+    uio_t *dstuio = NULL;
+    iovec_t *dstiov = NULL;
+
+    // SOURCE is always RAW
+    if (plaintext->cd_format != CRYPTO_DATA_RAW) {
+        printk("crypto_encrypt  cd_format is NOT RAW?! %d\n", plaintext->cd_format);
+        return CRYPTO_FAILED;
+    }
+
+    // DST can be RAW, or UIO
+    if ((ciphertext->cd_format == CRYPTO_DATA_UIO) &&
+        (ciphertext->cd_uio->uio_segflg == UIO_USERSPACE)) {
+        printk("crypto_encrypt  cipher cd_format is UIO?! segment is %s!!!\n",
+               ciphertext->cd_uio->uio_segflg == UIO_USERSPACE ? "user" : "system");
+        return CRYPTO_FAILED;
+    }
+
+    // We dont support MBLK at all
+    if (ciphertext->cd_format == CRYPTO_DATA_MBLK) {
+        printk("crypto_encrypt  cipher cd_format is MBLK?!\n");
+        return CRYPTO_FAILED;
+    }
+
+    // We do not handle callbacks (so far they've not been needed)
+    if (cr != NULL) {
+      printk("cyrpto_encrypt with callback request not supported\n");
+      return CRYPTO_FAILED;
+    }
+
+    src = (unsigned char *)plaintext->cd_raw.iov_base;
+    len = (size_t) plaintext->cd_length;
+
+    if (ciphertext && ciphertext->cd_raw.iov_base)
+        dst = (unsigned char *)ciphertext->cd_raw.iov_base;
+    else
+        dst = src;
+
+    if (ciphertext->cd_format == CRYPTO_DATA_UIO) {
+      dstuio = ciphertext->cd_uio;
+      numiov = dstuio->uio_iovcnt;
+      curriov = 0;
+      iovlen = 0; // Forces read of first iov.
+      dstiov = dstuio->uio_iov;
+      printk("crypto_encrypt: UIO :  with %u iovs: total 0x%04lx/0x%04lx\n",
+             numiov,
+             (unsigned long)len,
+             (unsigned long)plaintext->cd_raw.iov_len);
+    }
+
+    if (numiov == 0) {
+      printk("crypto_encrypt (%p -> %p) 0x%04lx/0x%04lx (offset 0x%04lx: numiov %u)\n",
+	     src, dst,
+             (unsigned long)len,
+             (unsigned long)plaintext->cd_raw.iov_len,
+             (unsigned long)plaintext->cd_offset,
+             numiov);
+    }
+
+    for (i = 0; i < len; i++) {
+
+        if (numiov && !iovlen) { // uses UIO, and ran out of space, move to next
+
+            dst = dstiov[ curriov ].iov_base;
+            iovlen = dstiov[ curriov ].iov_len;
+
+            printk("crypto_encrypt IOV (%p -> %p) curriov %u, iovlen 0x%04lx\n",
+                   src, dst, curriov, (unsigned long)iovlen);
+
+            curriov++; // Ready next.
+            if (curriov >= numiov) { // out of dst space
+                if (i < len) printk("crypto_encrypt ran outof dst space before src i=%d\n", i);
+                break;
+            }
+        } // if numiov
+
+        // ENCRYPT!
+        dst[i] = isalpha(src[i]) ? src[i]^0x20 : src[i];
+        //dst[i] = src[i];
+
+        // Decrease UIO, if used
+        if (iovlen) iovlen--;
+    }
+
+    printk("spl-crypto encrypt: done\n");
+    return CRYPTO_SUCCESS;
+#endif
+    ASSERT(1==0);
+    return CRYPTO_FAILED;
+}
+
+
+
+int crypto_create_ctx_template(crypto_mechanism_t *mech,
+    crypto_key_t *key, crypto_ctx_template_t *tmpl, int kmflag)
+{
+    return 0;
+}
+
+void crypto_destroy_ctx_template(crypto_ctx_template_t tmpl)
+{
+    return;
+}
+
+crypto_mech_type_t crypto_mech2id(crypto_mech_name_t name)
+{
+    if (!name || !*name)
+        return CRYPTO_MECH_INVALID;
+
+#if _KERNEL
+    printk("called crypto_mech2id '%s'\n", name);
+#endif
+    if (name && !strcmp("CKM_AES_CCM", name)) return 1;
+    return CRYPTO_MECH_INVALID;
+}
+
+
+#if _KERNEL
+
+EXPORT_SYMBOL(crypto_encrypt);
+EXPORT_SYMBOL(crypto_mac);
+EXPORT_SYMBOL(crypto_decrypt);
+EXPORT_SYMBOL(crypto_create_ctx_template);
+EXPORT_SYMBOL(crypto_destroy_ctx_template);
+EXPORT_SYMBOL(crypto_mech2id);
+
+#endif
+
+
+
+


### PR DESCRIPTION
Thanks for doing this, I am hoping my code will help with your work.

//

Add Solaris crypto API calls to SPL layer, translating into Linux crypto API. This code was not easy to work out, Linux crypto API
lacks any documentation.

However, there appears to be a "maximum length" limitation with
Linux scatterlist. It is better to use recordsize=512 when creating
encrypted filesystems for now.

Possibly large crypt calls need to be split up into more scatterlist
entries.

Code currently does not use ASYNC calls, as original ZFS appears not to.

'iv' is computed the same as Open Solaris sources.

The ctx_template functions should probably be used to acquire the tfm
instead of calling crypto_alloc_aead() each and every time.

Note this code is littered with debug prints.
