### PR TITLE
Fix scatterlists temporarily with tmp buffer

### DIFF
--- a/include/sys/crypto/api.h
+++ b/include/sys/crypto/api.h
@@ -32,6 +32,10 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/crypto/common.h>
 
+
+    //#define ZFS_CRYPTO_VERBOSE
+
+
 typedef long crypto_req_id_t;
 typedef void *crypto_bc_t;
 typedef void *crypto_context_t;


### PR DESCRIPTION
now we allocate a new linear memory for output, then call
sg_copy_from_buffer() to copy back to scatterlist. Note that using
scatterwalk_map_and_copy() instead will cause panic.

This fixes the recordsize=512 limit, all recordsizes work.

Fixed crypto_map_buffers() which took static 2 buffers to be dynamic. It
turns out ZFS will chain events, and was using over 28 on my tests.

ZFS-crypto can now do a simple bonnie run without crashing.

Created MACRO to crypto debug messages. Default is off. Removed old
cipher code, but left 3 alternate calls. AEAD (default), blkcipher, and
memcopy.

TODO: Solve the panic which scatterlists to remove the need to allocate
      dst temporary buffer.
